### PR TITLE
Shaded jar was broken due to a bug between jersey and spring boot

### DIFF
--- a/src/main/java/br/ufsc/inf/lapesd/linkedator/api/config/JerseyConfig.java
+++ b/src/main/java/br/ufsc/inf/lapesd/linkedator/api/config/JerseyConfig.java
@@ -3,6 +3,7 @@ package br.ufsc.inf.lapesd.linkedator.api.config;
 import javax.ws.rs.ApplicationPath;
 
 import br.ufsc.inf.lapesd.ld_jaxrs.jena.JenaProviders;
+import br.ufsc.inf.lapesd.linkedator.api.endpoint.LinkedatorApiEndpoint;
 import org.glassfish.jersey.server.ResourceConfig;
 import org.glassfish.jersey.server.spring.scope.RequestContextFilter;
 import org.springframework.stereotype.Component;
@@ -14,7 +15,7 @@ public class JerseyConfig extends ResourceConfig {
     public JerseyConfig() {
         this.register(RequestContextFilter.class);
         JenaProviders.getProviders().forEach(this::register);
-        this.packages("br.ufsc.inf.lapesd.linkedator.api.endpoint");
+        this.register(LinkedatorApiEndpoint.class);
         this.register(CorsInterceptor.class);
     }
 }


### PR DESCRIPTION
Spring Boot 1.4 changed jar internal structure, which breaks Jersey
class path scanning. Not asking jersey to classpath scan is the
easiest fix (as we only have one root resource class).