### PR TITLE
${config.ontologyFilePath} can be ommitted when using alignator.

### DIFF
--- a/src/main/java/br/ufsc/inf/lapesd/linkedator/api/endpoint/LinkedatorApiEndpoint.java
+++ b/src/main/java/br/ufsc/inf/lapesd/linkedator/api/endpoint/LinkedatorApiEndpoint.java
@@ -62,7 +62,7 @@ import static java.util.concurrent.TimeUnit.SECONDS;
 public class LinkedatorApiEndpoint {
     private static Log log = LogFactory.getLog(LinkedatorApiEndpoint.class);
 
-    @Value("${config.ontologyFilePath}")
+    @Value("${config.ontologyFilePath:null}")
     private String ontologyFilePath;
 
     @Value("${config.enableCache}")


### PR DESCRIPTION
Since alignator fixes the LinkedatorApiEndpoint.ontologyFilePath, it
is uncomfortable to demand a configuration that will be solemnly
ignored.