### PR TITLE
Load Alignator as a bean

### DIFF
--- a/beans.xml
+++ b/beans.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans xmlns="http://www.springframework.org/schema/beans"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:schemaLocation="http://www.springframework.org/schema/beans
+ http://www.springframework.org/schema/beans/spring-beans-3.0.xsd">
+
+    <bean id="ontologyMatcher" class="br.ufsc.inf.lapesd.alignator.core.ontology.matcher.ParisOntologyMatcher"/>
+</beans>

--- a/src/main/java/br/ufsc/inf/lapesd/linkedator/api/config/LinkedatorApiApplication.java
+++ b/src/main/java/br/ufsc/inf/lapesd/linkedator/api/config/LinkedatorApiApplication.java
@@ -4,11 +4,13 @@ import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.ImportResource;
 
 import javax.ws.rs.ApplicationPath;
 
 @EnableAutoConfiguration
 @SpringBootApplication
+@ImportResource("file:beans.xml")
 @ComponentScan("br.ufsc.inf.lapesd")
 public class LinkedatorApiApplication {
 

--- a/src/main/java/br/ufsc/inf/lapesd/linkedator/api/endpoint/LinkedatorApiEndpoint.java
+++ b/src/main/java/br/ufsc/inf/lapesd/linkedator/api/endpoint/LinkedatorApiEndpoint.java
@@ -62,7 +62,7 @@ import static java.util.concurrent.TimeUnit.SECONDS;
 public class LinkedatorApiEndpoint {
     private static Log log = LogFactory.getLog(LinkedatorApiEndpoint.class);
 
-    @Value("${config.ontologyFilePath}")
+    @Value("${config.ontologyFilePath:null}")
     private String ontologyFilePath;
 
     @Value("${config.enableCache}")


### PR DESCRIPTION
In order to allow setting the `OntologyMatcher` implementation used by Alignator, it must be instantiated as a Bean. The implementation of `OntologyMatcher` to be used can now be configured on `beans.xml`